### PR TITLE
The big refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ all: $(SONAME) pty
 $(SONAME): lua_tmt.c tmt.c
 	$(CC) -shared -o $@ $(LUA_CFLAGS) $(LUA_LIBS) $^
 
-pty: $(PTY_SRC)
-	$(CC) -o $@ $(PTY_CFLAGS) $(PTY_LIBS) $<
+pty: $(PTY_SRC) minivt.c
+	$(CC) -o $@ $(PTY_CFLAGS) $(PTY_LIBS) $^
 
 mingw:
 	$(MAKE) PTY_LIBS=-lwinpty SOEXT=dll PTY_SRC=pty.win.c

--- a/init.lua
+++ b/init.lua
@@ -151,8 +151,8 @@ function TmtView:draw()
     ox, oy = ox + style.padding.x, oy + style.padding.y
 
     for i = 1, screen.width * screen.height do
-        local cy = math.floor(i / screen.width)
-        local cx = i % screen.width
+        local cy = math.floor((i - 1) / screen.width)
+        local cx = (i - 1) % screen.width
 
         local x, y = ox + cx * fw, oy + cy * fh
         local cell = screen[i]

--- a/init.lua
+++ b/init.lua
@@ -138,7 +138,7 @@ function TmtView:get_screen_char_size()
         math.max(1, math.floor(y / font:get_height()))
 end
 
-local invisible = { "\r", "\n", "\v", "\t", "\f", " " }
+local invisible = { ["\r"] = true, ["\n"] = true, ["\v"] = true, ["\t"] = true, ["\f"] = true, [" "] = true }
 function TmtView:draw()
     self:draw_background(style.background)
     local font = style.code_font

--- a/lua_tmt.c
+++ b/lua_tmt.c
@@ -218,7 +218,7 @@ static int l_new(lua_State *L) {
 
 	TMT *vt = tmt_open((size_t)h, (size_t)w, input_callback, tmt, NULL); 
 	if (vt == NULL)
-		luaL_error(L, "cannot create virtual terminal");
+		return luaL_error(L, "cannot create virtual terminal");
 
 	tmt->vt = vt;
 

--- a/lua_tmt.c
+++ b/lua_tmt.c
@@ -21,13 +21,13 @@
 
 
 typedef struct {
-	TMT *vt;
-	int update_lines;
-	int update_bell;
-	int update_answer;
-	int update_cursor;
-	char *answer;
-	size_t answer_len, answer_size;
+    TMT *vt;
+    int update_lines;
+    int update_bell;
+    int update_answer;
+    int update_cursor;
+    char *answer;
+    size_t answer_len, answer_size;
 } tmt_t;
 
 
@@ -35,252 +35,252 @@ typedef struct {
 // nobody likes wchar_t
 static int wchar_convert(wchar_t c, char *s) {
 #ifndef __WIN32
-	return wctomb(s, c);
+    return wctomb(s, c);
 #else
-	int ret = WideCharToMultiByte(CP_UTF8, 0, &c, 1, s, 4, NULL, NULL);
-	return ret == 0 ? -1 : ret;
+    int ret = WideCharToMultiByte(CP_UTF8, 0, &c, 1, s, 4, NULL, NULL);
+    return ret == 0 ? -1 : ret;
 #endif
 }
 
 
 
 static int l_write(lua_State *L) {
-	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
-	const char* str = luaL_checkstring(L, 2);
+    tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
+    const char* str = luaL_checkstring(L, 2);
 
-	const TMTPOINT *c = tmt_cursor(tmt->vt);
+    const TMTPOINT *c = tmt_cursor(tmt->vt);
 
-	tmt_write(tmt->vt, str, 0);
+    tmt_write(tmt->vt, str, 0);
 
-	lua_newtable(L);
-	LUA_T_PUSH_S_B("screen", tmt->update_lines);
-	LUA_T_PUSH_S_B("bell", tmt->update_bell);
-	if (tmt->update_answer) {
-		lua_pushlstring(L, tmt->answer, tmt->answer_len);
-		lua_setfield(L, -2, "answer");
-		tmt->answer_len = 0;
-	}
+    lua_newtable(L);
+    LUA_T_PUSH_S_B("screen", tmt->update_lines);
+    LUA_T_PUSH_S_B("bell", tmt->update_bell);
+    if (tmt->update_answer) {
+        lua_pushlstring(L, tmt->answer, tmt->answer_len);
+        lua_setfield(L, -2, "answer");
+        tmt->answer_len = 0;
+    }
 
-	if (tmt->update_cursor) {
-		lua_newtable(L);
-		LUA_T_PUSH_S_I("x", c->c + 1);
-		LUA_T_PUSH_S_I("y", c->r + 1);
-		lua_setfield(L, -2, "cursor");
-	}
+    if (tmt->update_cursor) {
+        lua_newtable(L);
+        LUA_T_PUSH_S_I("x", c->c + 1);
+        LUA_T_PUSH_S_I("y", c->r + 1);
+        lua_setfield(L, -2, "cursor");
+    }
 
-	tmt->update_lines = 0;
-	tmt->update_bell = 0;
-	tmt->update_answer = 0;
-	tmt->update_cursor = 0;
+    tmt->update_lines = 0;
+    tmt->update_bell = 0;
+    tmt->update_answer = 0;
+    tmt->update_cursor = 0;
 
-	return 1;
+    return 1;
 }
 
 
 
 void insert_char_table(lua_State *L, int x, TMTCHAR c) {
-	lua_rawgeti(L, -1, x+1);
+    lua_rawgeti(L, -1, x+1);
 
 #ifdef __WIN32
-	char cp[UTF8_SIZE];
+    char cp[UTF8_SIZE];
 #else
-	char cp[MB_CUR_MAX];
+    char cp[MB_CUR_MAX];
 #endif
-	int sz = wchar_convert(c.c, cp);
-	if (sz == -1)
-		lua_pushliteral(L, " ");
-	else
-		lua_pushlstring(L, cp, sz);
-	lua_setfield(L, -2, "char");
+    int sz = wchar_convert(c.c, cp);
+    if (sz == -1)
+        lua_pushliteral(L, " ");
+    else
+        lua_pushlstring(L, cp, sz);
+    lua_setfield(L, -2, "char");
 
-	LUA_T_PUSH_S_I("fg", (int)c.a.fg);
-	LUA_T_PUSH_S_I("bg", (int)c.a.bg);
+    LUA_T_PUSH_S_I("fg", (int)c.a.fg);
+    LUA_T_PUSH_S_I("bg", (int)c.a.bg);
 
-	LUA_T_PUSH_S_B("bold", c.a.bold);
-	LUA_T_PUSH_S_B("dim", c.a.dim);
-	LUA_T_PUSH_S_B("underline", c.a.underline);
-	LUA_T_PUSH_S_B("blink", c.a.blink);
-	LUA_T_PUSH_S_B("reverse", c.a.reverse);
-	LUA_T_PUSH_S_B("invisible", c.a.invisible);
+    LUA_T_PUSH_S_B("bold", c.a.bold);
+    LUA_T_PUSH_S_B("dim", c.a.dim);
+    LUA_T_PUSH_S_B("underline", c.a.underline);
+    LUA_T_PUSH_S_B("blink", c.a.blink);
+    LUA_T_PUSH_S_B("reverse", c.a.reverse);
+    LUA_T_PUSH_S_B("invisible", c.a.invisible);
 
-	lua_pop(L, 1);
+    lua_pop(L, 1);
 }
 
 
 
 static int l_get_screen(lua_State *L) {
-	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
-	const TMTSCREEN *s = tmt_screen(tmt->vt);
+    tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
+    const TMTSCREEN *s = tmt_screen(tmt->vt);
 
-	if (!lua_istable(L, 2))
-		lua_createtable(L, s->nline * s->ncol, 2);
+    if (!lua_istable(L, 2))
+        lua_createtable(L, s->nline * s->ncol, 2);
 
-	lua_settop(L, 2);
+    lua_settop(L, 2);
 
-	LUA_T_PUSH_S_I("width", s->ncol);
-	LUA_T_PUSH_S_I("height", s->nline);
+    LUA_T_PUSH_S_I("width", s->ncol);
+    LUA_T_PUSH_S_I("height", s->nline);
 
-	// ensure enough objects for later
-	unsigned int l = s->nline * s->ncol;
-	if (lua_rawlen(L, -1) < l) {
-		for (unsigned int i = lua_rawlen(L, -1) + 1; i <= l; i++) {
-			lua_newtable(L);
-			lua_rawseti(L, -2, i);
-		}
-	}
+    // ensure enough objects for later
+    unsigned int l = s->nline * s->ncol;
+    if (lua_rawlen(L, -1) < l) {
+        for (unsigned int i = lua_rawlen(L, -1) + 1; i <= l; i++) {
+            lua_newtable(L);
+            lua_rawseti(L, -2, i);
+        }
+    }
 
-	for (size_t y = 0; y < s->nline; y++) {
-		if (!s->lines[y]->dirty) continue;
-		for (size_t x = 0; x < s->ncol; x++) {
-			insert_char_table(L, (y * s->ncol) + x, s->lines[y]->chars[x]);
-		}
-	}
+    for (size_t y = 0; y < s->nline; y++) {
+        if (!s->lines[y]->dirty) continue;
+        for (size_t x = 0; x < s->ncol; x++) {
+            insert_char_table(L, (y * s->ncol) + x, s->lines[y]->chars[x]);
+        }
+    }
 
-	tmt_clean(tmt->vt); // reset dirty flags
-	return 1;
+    tmt_clean(tmt->vt); // reset dirty flags
+    return 1;
 }
 
 
 
 static int l_get_cursor(lua_State *L) {
-	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
-	const TMTPOINT *c = tmt_cursor(tmt->vt);
-	
-	lua_pushinteger(L, c->c+1);
-	lua_pushinteger(L, c->r+1);
-	return 2;
+    tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
+    const TMTPOINT *c = tmt_cursor(tmt->vt);
+
+    lua_pushinteger(L, c->c+1);
+    lua_pushinteger(L, c->r+1);
+    return 2;
 }
 
 
 
 static int l_set_size(lua_State *L) {
-	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
-	int w = lua_tointeger(L, 2);
-	int h = lua_tointeger(L, 3);
+    tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
+    int w = lua_tointeger(L, 2);
+    int h = lua_tointeger(L, 3);
 
-	tmt_resize(tmt->vt, (size_t)h, (size_t)w);
-	return 0;
+    tmt_resize(tmt->vt, (size_t)h, (size_t)w);
+    return 0;
 }
 
 
 
 static int l_get_size(lua_State *L) {
-	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
-	const TMTSCREEN *s = tmt_screen(tmt->vt);
+    tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
+    const TMTSCREEN *s = tmt_screen(tmt->vt);
 
-	lua_pushinteger(L, s->ncol);
-	lua_pushinteger(L, s->nline);
-	return 2;
+    lua_pushinteger(L, s->ncol);
+    lua_pushinteger(L, s->nline);
+    return 2;
 }
 
 
 
 void append_answer(tmt_t *tmt, const char *a) {
-	size_t len = strlen(a) + 1; // counting \0 at the end
-	if (tmt->answer_len + len > tmt->answer_size) {
-		char *new = realloc(tmt->answer, (tmt->answer_size *= 2) * sizeof(char));
-		if (new == NULL) {
-			fprintf(stderr, __FILE__ ": cannot allocate memory for answer\n");
-			return;
-		}
-		tmt->answer = new;
-	}
-	memcpy(tmt->answer + tmt->answer_len, a, len);
-	tmt->answer_len += (len - 1);
+    size_t len = strlen(a) + 1; // counting \0 at the end
+    if (tmt->answer_len + len > tmt->answer_size) {
+        char *new = realloc(tmt->answer, (tmt->answer_size *= 2) * sizeof(char));
+        if (new == NULL) {
+            fprintf(stderr, __FILE__ ": cannot allocate memory for answer\n");
+            return;
+        }
+        tmt->answer = new;
+    }
+    memcpy(tmt->answer + tmt->answer_len, a, len);
+    tmt->answer_len += (len - 1);
 }
 
 
 
 void input_callback(tmt_msg_t m, TMT *vt, const void *a, void *p) {
-	tmt_t *tmt = (tmt_t*)p;
-	if (tmt->vt == NULL || tmt->answer == NULL) return;
+    tmt_t *tmt = (tmt_t*)p;
+    if (tmt->vt == NULL || tmt->answer == NULL) return;
 
-	switch (m){
-		case TMT_MSG_BELL:
-			tmt->update_bell = 1;
-			break;
-		case TMT_MSG_UPDATE:
-			/* the screen image changed; a is a pointer to the TMTSCREEN */
-			tmt->update_lines = 1;
-			break;
-		case TMT_MSG_ANSWER:
-			/* the terminal has a response to give to the program; a is a
-			 * pointer to a string */
-			tmt->update_answer = 1;
-			append_answer(tmt, (const char *)a);
-			break;
-		case TMT_MSG_MOVED:
-			/* the cursor moved; a is a pointer to the cursor's TMTPOINT */
-			tmt->update_cursor = 1;
-			break;
-		case TMT_MSG_CURSOR:
-			break;
-	}
+    switch (m){
+        case TMT_MSG_BELL:
+            tmt->update_bell = 1;
+            break;
+        case TMT_MSG_UPDATE:
+            /* the screen image changed; a is a pointer to the TMTSCREEN */
+            tmt->update_lines = 1;
+            break;
+        case TMT_MSG_ANSWER:
+            /* the terminal has a response to give to the program; a is a
+             * pointer to a string */
+            tmt->update_answer = 1;
+            append_answer(tmt, (const char *)a);
+            break;
+        case TMT_MSG_MOVED:
+            /* the cursor moved; a is a pointer to the cursor's TMTPOINT */
+            tmt->update_cursor = 1;
+            break;
+        case TMT_MSG_CURSOR:
+            break;
+    }
 }
 
 
 
 static int l_new(lua_State *L) {
-	int w = luaL_optinteger(L, 1, 80);
-	int h = luaL_optinteger(L, 2, 24);
+    int w = luaL_optinteger(L, 1, 80);
+    int h = luaL_optinteger(L, 2, 24);
 
-	tmt_t *tmt = (tmt_t *)lua_newuserdata(L, sizeof(tmt_t));
-	luaL_setmetatable(L, API_TYPE_TMT);
+    tmt_t *tmt = (tmt_t *)lua_newuserdata(L, sizeof(tmt_t));
+    luaL_setmetatable(L, API_TYPE_TMT);
 
-	TMT *vt = tmt_open((size_t)h, (size_t)w, input_callback, tmt, NULL); 
-	if (vt == NULL)
-		return luaL_error(L, "cannot create virtual terminal");
+    TMT *vt = tmt_open((size_t)h, (size_t)w, input_callback, tmt, NULL); 
+    if (vt == NULL)
+        return luaL_error(L, "cannot create virtual terminal");
 
-	tmt->vt = vt;
-	tmt->update_lines = 0;
-	tmt->update_bell = 0;
-	tmt->update_answer = 0;
-	tmt->update_cursor = 0;
-	tmt->answer_len = 0;
-	tmt->answer_size = ANS_SIZE;
-	tmt->answer = malloc(tmt->answer_size * sizeof(char));
-	if (tmt->answer == NULL) {
-		tmt_close(vt);
-		return luaL_error(L, "cannot create virtual terminal");
-	}
-	return 1;
+    tmt->vt = vt;
+    tmt->update_lines = 0;
+    tmt->update_bell = 0;
+    tmt->update_answer = 0;
+    tmt->update_cursor = 0;
+    tmt->answer_len = 0;
+    tmt->answer_size = ANS_SIZE;
+    tmt->answer = malloc(tmt->answer_size * sizeof(char));
+    if (tmt->answer == NULL) {
+        tmt_close(vt);
+        return luaL_error(L, "cannot create virtual terminal");
+    }
+    return 1;
 }
 
 
 
 static int l_gc(lua_State *L) {
-	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
-	if (tmt->vt != NULL) {
-		tmt_close(tmt->vt);
-		tmt->vt = NULL;
-	}
-	if (tmt->answer != NULL) {
-		free(tmt->answer);
-		tmt->answer = NULL;
-	}
-	return 0;
+    tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
+    if (tmt->vt != NULL) {
+        tmt_close(tmt->vt);
+        tmt->vt = NULL;
+    }
+    if (tmt->answer != NULL) {
+        free(tmt->answer);
+        tmt->answer = NULL;
+    }
+    return 0;
 }
 
 
 
 static const luaL_Reg lib[] = {
-	{ "new", l_new },
-	{ "write", l_write },
-	{ "get_screen", l_get_screen },
-	{ "get_cursor", l_get_cursor },
-	{ "get_size", l_get_size },
-	{ "set_size", l_set_size },
-	{ "__gc", l_gc },
-	{ NULL, NULL }
+    { "new", l_new },
+    { "write", l_write },
+    { "get_screen", l_get_screen },
+    { "get_cursor", l_get_cursor },
+    { "get_size", l_get_size },
+    { "set_size", l_set_size },
+    { "__gc", l_gc },
+    { NULL, NULL }
 };
 
 
 
 int luaopen_tmt(lua_State *L) {
-	setlocale(LC_CTYPE, "en_US.UTF-8");
-	luaL_newmetatable(L, API_TYPE_TMT);
-	lua_pushvalue(L, -1);
-	lua_setfield(L, -2, "__index");
-	luaL_setfuncs(L, lib, 0);
-	return 1;
+    setlocale(LC_CTYPE, "en_US.UTF-8");
+    luaL_newmetatable(L, API_TYPE_TMT);
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -2, "__index");
+    luaL_setfuncs(L, lib, 0);
+    return 1;
 }

--- a/lua_tmt.c
+++ b/lua_tmt.c
@@ -1,13 +1,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include <locale.h>
+#include <lua.h>
+#include <lauxlib.h>
 
 #ifdef __WIN32
 #include <windows.h>
 #endif
-
-#include <lua.h>
-#include <lauxlib.h>
 
 #include "tmt.h"
 
@@ -16,9 +15,10 @@
 #define LUA_T_PUSH_S_B(S, N) (lua_pushboolean(L, N), lua_setfield(L, -2, S))
 #define LUA_T_PUSH_S_S(K, V) (lua_pushstring(L, V), lua_setfield(L, -2, K))
 
-
+#define UTF8_SIZE 4
 #define ANS_SIZE 256
 #define API_TYPE_TMT "tmt"
+
 
 typedef struct {
 	TMT *vt;
@@ -82,7 +82,7 @@ void insert_char_table(lua_State *L, int x, TMTCHAR c) {
 	lua_rawgeti(L, -1, x+1);
 
 #ifdef __WIN32
-	char cp[4];
+	char cp[UTF8_SIZE];
 #else
 	char cp[MB_CUR_MAX];
 #endif
@@ -159,7 +159,6 @@ static int l_set_size(lua_State *L) {
 	int h = lua_tointeger(L, 3);
 
 	tmt_resize(tmt->vt, (size_t)h, (size_t)w);
-
 	return 0;
 }
 
@@ -244,7 +243,6 @@ static int l_new(lua_State *L) {
 		tmt_close(vt);
 		return luaL_error(L, "cannot create virtual terminal");
 	}
-
 	return 1;
 }
 
@@ -284,6 +282,5 @@ int luaopen_tmt(lua_State *L) {
 	lua_pushvalue(L, -1);
 	lua_setfield(L, -2, "__index");
 	luaL_setfuncs(L, lib, 0);
-
 	return 1;
 }

--- a/lua_tmt.c
+++ b/lua_tmt.c
@@ -1,26 +1,23 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <termios.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
 #include <string.h>
-#include <time.h>
+#include <stdlib.h>
+#include <locale.h>
+
+#ifdef __WIN32
+#include <windows.h>
+#endif
+
+#include <lua.h>
+#include <lauxlib.h>
 
 #include "tmt.h"
 
-#define LUA_T_PUSH_S_N(S, N) lua_pushstring(L, S); lua_pushnumber(L, N); lua_settable(L, -3);
-#define LUA_T_PUSH_S_I(S, N) lua_pushstring(L, S); lua_pushinteger(L, N); lua_settable(L, -3);
-#define LUA_T_PUSH_S_B(S, N) lua_pushstring(L, S); lua_pushboolean(L, N); lua_settable(L, -3);
-#define LUA_T_PUSH_S_S(S, S2) lua_pushstring(L, S); lua_pushstring(L, S2); lua_settable(L, -3);
-#define LUA_T_PUSH_S_CF(S, CF) lua_pushstring(L, S); lua_pushcfunction(L, CF); lua_settable(L, -3);
-#define CHECK_TMT(L, I, T) T=(tmt_t *)luaL_checkudata(L, I, "tmt"); if (T==NULL) { lua_pushnil(L); lua_pushfstring(L, "Argument %d must be a TMT", I); return 2; }
+
+#define LUA_T_PUSH_S_I(S, N) (lua_pushinteger(L, N), lua_setfield(L, -2, S))
+#define LUA_T_PUSH_S_B(S, N) (lua_pushboolean(L, N), lua_setfield(L, -2, S))
+#define LUA_T_PUSH_S_S(K, V) (lua_pushstring(L, V), lua_setfield(L, -2, K))
 
 
-#define NS_IN_S 1000000000
-
+#define API_TYPE_TMT "tmt"
 
 typedef struct {
 	TMT *vt;
@@ -34,11 +31,21 @@ typedef struct {
 } tmt_t;
 
 
-static int l_write(lua_State *L) {
-	struct timespec t;
 
-	tmt_t *tmt;
-	CHECK_TMT(L, 1, tmt)
+// nobody likes wchar_t
+static int wchar_convert(wchar_t c, char *s) {
+#ifndef __WIN32
+	return wctomb(s, c);
+#else
+	int ret = WideCharToMultiByte(CP_UTF8, 0, &c, 1, s, 4, NULL, NULL);
+	return ret == 0 ? -1 : ret;
+#endif
+}
+
+
+
+static int l_write(lua_State *L) {
+	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
 	const char* str = luaL_checkstring(L, 2);
 
 	const TMTPOINT *c = tmt_cursor(tmt->vt);
@@ -46,136 +53,100 @@ static int l_write(lua_State *L) {
 	tmt_write(tmt->vt, str, 0);
 
 	lua_newtable(L);
-
-	int counter = 1;
-
-	if (clock_gettime(CLOCK_REALTIME, &t) == 0) {
-		LUA_T_PUSH_S_N("time", (double)t.tv_sec + ((double)t.tv_nsec)/NS_IN_S)
-	}
-
-	if (tmt->update_lines) {
-		tmt->update_lines = 0;
-
-		lua_pushinteger(L, counter);
-		lua_newtable(L);
-
-		LUA_T_PUSH_S_S("type", "screen")
-
-		lua_settable(L, -3);
-
-		counter = counter + 1;
-	}
-
-	if (tmt->update_bell) {
-		tmt->update_bell = 0;
-
-		lua_pushinteger(L, counter);
-		lua_newtable(L);
-
-		LUA_T_PUSH_S_S("type", "bell")
-
-		lua_settable(L, -3);
-
-		counter = counter + 1;
-	}
-
+	LUA_T_PUSH_S_B("screen", tmt->update_lines);
+	LUA_T_PUSH_S_B("bell", tmt->update_bell);
 	if (tmt->update_answer) {
-		tmt->update_answer = 0;
-
-		lua_pushinteger(L, counter);
-		lua_newtable(L);
-
-		LUA_T_PUSH_S_S("type", "answer")
-		LUA_T_PUSH_S_S("answer", tmt->answer)
-
+		LUA_T_PUSH_S_S("answer", tmt->answer);
 		free(tmt->answer);
 		tmt->answer = NULL;
-
-		lua_settable(L, -3);
-
-		counter = counter + 1;
 	}
 
 	if (tmt->update_cursor) {
-		tmt->update_cursor = 0;
-
-		lua_pushinteger(L, counter);
 		lua_newtable(L);
-
-		LUA_T_PUSH_S_S("type", "cursor")
-		LUA_T_PUSH_S_I("x", c->c+1)
-		LUA_T_PUSH_S_I("y", c->r+1)
-		
-		lua_settable(L, -3);
-
-		counter = counter + 1;
+		LUA_T_PUSH_S_I("x", c->c + 1);
+		LUA_T_PUSH_S_I("y", c->r + 1);
+		lua_setfield(L, -2, "cursor");
 	}
+
+	tmt->update_lines = 0;
+	tmt->update_bell = 0;
+	tmt->update_answer = 0;
+	tmt->update_cursor = 0;
 
 	return 1;
 }
 
 
 
-void insert_char_table(int x, lua_State *L, TMTCHAR c) {
-	lua_pushinteger(L, x+1);
-	lua_newtable(L);
+void insert_char_table(lua_State *L, int x, TMTCHAR c) {
+	lua_rawgeti(L, -1, x+1);
 
-	LUA_T_PUSH_S_I("char", c.c)
-	LUA_T_PUSH_S_I("fg", (int)c.a.fg)
-	LUA_T_PUSH_S_I("bg", (int)c.a.bg)
+#ifdef __WIN32
+	char cp[4];
+#else
+	char cp[MB_CUR_MAX];
+#endif
+	int sz = wchar_convert(c.c, cp);
+	if (sz == -1)
+		lua_pushliteral(L, " ");
+	else
+		lua_pushlstring(L, cp, sz);
+	lua_setfield(L, -2, "char");
 
-	LUA_T_PUSH_S_B("bold", c.a.bold? 1 : 0)
-	LUA_T_PUSH_S_B("dim", c.a.dim? 1 : 0)
-	LUA_T_PUSH_S_B("underline", c.a.underline? 1 : 0)
-	LUA_T_PUSH_S_B("blink", c.a.blink? 1 : 0)
-	LUA_T_PUSH_S_B("reverse", c.a.reverse? 1 : 0)
-	LUA_T_PUSH_S_B("invisible", c.a.invisible? 1 : 0)
+	LUA_T_PUSH_S_I("fg", (int)c.a.fg);
+	LUA_T_PUSH_S_I("bg", (int)c.a.bg);
 
-	lua_settable(L, -3);
+	LUA_T_PUSH_S_B("bold", c.a.bold);
+	LUA_T_PUSH_S_B("dim", c.a.dim);
+	LUA_T_PUSH_S_B("underline", c.a.underline);
+	LUA_T_PUSH_S_B("blink", c.a.blink);
+	LUA_T_PUSH_S_B("reverse", c.a.reverse);
+	LUA_T_PUSH_S_B("invisible", c.a.invisible);
+
+	lua_pop(L, 1);
 }
 
-void insert_lines(lua_State *L, TMT *vt) {
-	const TMTSCREEN *s = tmt_screen(vt);
-	lua_pushstring(L, "lines");
-	lua_newtable(L);
-	
-	for (uint y=0; y < s->nline; y++) {
-		lua_pushinteger(L, y+1);
-		lua_newtable(L);
 
-		LUA_T_PUSH_S_B("dirty", s->lines[y]->dirty? 1 : 0)
-
-		for (uint x=0; x < s->ncol; x++) {
-			insert_char_table(x, L, s->lines[y]->chars[x]);
-		}
-		lua_settable(L, -3);
-	}
-	
-	lua_settable(L, -3);
-}
 
 static int l_get_screen(lua_State *L) {
-	tmt_t *tmt;
-	CHECK_TMT(L, 1, tmt)
-	TMT *vt = tmt->vt;
+	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
+	if (!lua_istable(L, 2))
+		lua_createtable(L, tmt->w * tmt->h, 2);
 
-	lua_newtable(L);
-	
+	lua_settop(L, 2);
+
+	const TMTSCREEN *s = tmt_screen(tmt->vt);
+	tmt->w = s->ncol;
+	tmt->h = s->nline;
+
 	LUA_T_PUSH_S_I("width", tmt->w);
 	LUA_T_PUSH_S_I("height", tmt->h);
-	
-	insert_lines(L, vt);
-	
+
+	// ensure enough objects for later
+	int l = tmt->w * tmt->h;
+	if (lua_rawlen(L, -1) < l) {
+		for (int i = lua_rawlen(L, -1) + 1; i <= l; i++) {
+			lua_newtable(L);
+			lua_rawseti(L, -2, i);
+		}
+	}
+
+	for (size_t y = 0; y < s->nline; y++) {
+		if (!s->lines[y]->dirty) continue;
+		for (size_t x = 0; x < s->ncol; x++) {
+			insert_char_table(L, (y * s->ncol) + x, s->lines[y]->chars[x]);
+		}
+	}
+
+	tmt_clean(tmt->vt); // reset dirty flags
 	return 1;
 }
 
 
 
 static int l_get_cursor(lua_State *L) {
-	tmt_t *tmt;
-	CHECK_TMT(L, 1, tmt)
-	TMT *vt = tmt->vt;
-	const TMTPOINT *c = tmt_cursor(vt);
+	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
+	const TMTPOINT *c = tmt_cursor(tmt->vt);
 	
 	lua_pushinteger(L, c->c+1);
 	lua_pushinteger(L, c->r+1);
@@ -185,16 +156,13 @@ static int l_get_cursor(lua_State *L) {
 
 
 static int l_set_size(lua_State *L) {
-	tmt_t *tmt;
-	CHECK_TMT(L, 1, tmt)
-	TMT *vt = tmt->vt;
-
+	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
 	int w = lua_tointeger(L, 2);
 	int h = lua_tointeger(L, 3);
 
 	tmt->w = w;
 	tmt->h = h;
-	tmt_resize(vt, (size_t)h, (size_t)w);
+	tmt_resize(tmt->vt, (size_t)h, (size_t)w);
 
 	return 0;
 }
@@ -202,8 +170,7 @@ static int l_set_size(lua_State *L) {
 
 
 static int l_get_size(lua_State *L) {
-	tmt_t *tmt;
-	CHECK_TMT(L, 1, tmt);
+	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
 
 	lua_pushinteger(L, tmt->w);
 	lua_pushinteger(L, tmt->h);
@@ -214,41 +181,44 @@ static int l_get_size(lua_State *L) {
 
 
 void input_callback(tmt_msg_t m, TMT *vt, const void *a, void *p) {
-	//lua_State *L = (lua_State*)p;
 	tmt_t *tmt = (tmt_t*)p;
-	//CHECK_TMT(L, 1, tmt)
-
-	if (tmt != NULL) {
-		switch (m){
-			case TMT_MSG_BELL:
-				tmt->update_bell = 1;
-				break;
-			case TMT_MSG_UPDATE:
-				/* the screen image changed; a is a pointer to the TMTSCREEN */
-				tmt->update_lines = 1;
-				break;
-			case TMT_MSG_ANSWER:
-				/* the terminal has a response to give to the program; a is a
-				 * pointer to a string */
-				tmt->answer = strdup((const char *)a);
-				tmt->update_answer = 1;
-				break;
-			case TMT_MSG_MOVED:
-				/* the cursor moved; a is a pointer to the cursor's TMTPOINT */
-				tmt->update_cursor = 1;
-				break;
-			case TMT_MSG_CURSOR:
-				break;
-		}
+	switch (m){
+		case TMT_MSG_BELL:
+			tmt->update_bell = 1;
+			break;
+		case TMT_MSG_UPDATE:
+			/* the screen image changed; a is a pointer to the TMTSCREEN */
+			tmt->update_lines = 1;
+			break;
+		case TMT_MSG_ANSWER:
+			/* the terminal has a response to give to the program; a is a
+			 * pointer to a string */
+			if (tmt->answer != NULL)
+				free(tmt->answer);
+			tmt->answer = strdup((const char *)a);
+			tmt->update_answer = 1;
+			break;
+		case TMT_MSG_MOVED:
+			/* the cursor moved; a is a pointer to the cursor's TMTPOINT */
+			tmt->update_cursor = 1;
+			break;
+		case TMT_MSG_CURSOR:
+			break;
 	}
 }
 
-static int l_new(lua_State *L) {
-	tmt_t *tmt = (tmt_t *)lua_newuserdata(L, sizeof(tmt_t));
-	int w = lua_tointeger(L, 1);
-	int h = lua_tointeger(L, 2);
 
-	TMT *vt = tmt_open((size_t)h, (size_t)w, input_callback, tmt, NULL);
+
+static int l_new(lua_State *L) {
+	int w = luaL_optinteger(L, 1, 80);
+	int h = luaL_optinteger(L, 2, 24);
+
+	tmt_t *tmt = (tmt_t *)lua_newuserdata(L, sizeof(tmt_t));
+	luaL_setmetatable(L, API_TYPE_TMT);
+
+	TMT *vt = tmt_open((size_t)h, (size_t)w, input_callback, tmt, NULL); 
+	if (vt == NULL)
+		luaL_error(L, "cannot create virtual terminal");
 
 	tmt->vt = vt;
 
@@ -258,43 +228,47 @@ static int l_new(lua_State *L) {
 	tmt->update_bell = 0;
 	tmt->update_answer = 0;
 	tmt->update_cursor = 0;
+	tmt->answer = NULL;
 
-	if (luaL_newmetatable(L, "tmt")) {
-		lua_pushstring(L, "__index");
-		lua_newtable(L);
-		LUA_T_PUSH_S_CF("write", l_write)
-		LUA_T_PUSH_S_CF("get_screen", l_get_screen)
-		LUA_T_PUSH_S_CF("get_cursor", l_get_cursor)
-		LUA_T_PUSH_S_CF("get_size", l_get_size)
-		LUA_T_PUSH_S_CF("set_size", l_set_size)
-		lua_settable(L, -3);
-	}
-
-	lua_setmetatable(L, -2);
 	return 1;
 }
 
 
 
-LUALIB_API int luaopen_plugins_tmt_tmt(lua_State *L) {
-	lua_newtable(L);
-	LUA_T_PUSH_S_CF("new", l_new)
+static int l_gc(lua_State *L) {
+	tmt_t *tmt = luaL_checkudata(L, 1, API_TYPE_TMT);
+	if (tmt->vt != NULL) {
+		tmt_close(tmt->vt);
+		tmt->vt = NULL;
+	}
+	if (tmt->answer != NULL) {
+		free(tmt->answer);
+		tmt->answer = NULL;
+	}
+	return 0;
+}
 
-	lua_pushstring(L, "special_keys");
-	lua_newtable(L);
-	LUA_T_PUSH_S_S("KEY_UP", TMT_KEY_UP)
-	LUA_T_PUSH_S_S("KEY_DOWN", TMT_KEY_DOWN)
-	LUA_T_PUSH_S_S("KEY_RIGHT", TMT_KEY_RIGHT)
-	LUA_T_PUSH_S_S("KEY_LEFT", TMT_KEY_LEFT)
-	LUA_T_PUSH_S_S("KEY_HOME", TMT_KEY_HOME)
-	LUA_T_PUSH_S_S("KEY_END", TMT_KEY_END)
-	LUA_T_PUSH_S_S("KEY_INSERT", TMT_KEY_INSERT)
-	LUA_T_PUSH_S_S("KEY_BACKSPACE", TMT_KEY_BACKSPACE)
-	LUA_T_PUSH_S_S("KEY_ESCAPE", TMT_KEY_ESCAPE)
-	LUA_T_PUSH_S_S("KEY_BACK_TAB", TMT_KEY_BACK_TAB)
-	LUA_T_PUSH_S_S("KEY_PAGE_UP", TMT_KEY_PAGE_UP)
-	LUA_T_PUSH_S_S("KEY_PAGE_DOWN", TMT_KEY_PAGE_DOWN)
-	lua_settable(L, -3);
+
+
+static const luaL_Reg lib[] = {
+	{ "new", l_new },
+	{ "write", l_write },
+	{ "get_screen", l_get_screen },
+	{ "get_cursor", l_get_cursor },
+	{ "get_size", l_get_size },
+	{ "set_size", l_set_size },
+	{ "__gc", l_gc },
+	{ NULL, NULL }
+};
+
+
+
+int luaopen_tmt(lua_State *L) {
+	setlocale(LC_CTYPE, "en_US.UTF-8");
+	luaL_newmetatable(L, API_TYPE_TMT);
+	lua_pushvalue(L, -1);
+	lua_setfield(L, -2, "__index");
+	luaL_setfuncs(L, lib, 0);
 
 	return 1;
 }

--- a/lua_tmt.c
+++ b/lua_tmt.c
@@ -194,6 +194,8 @@ void append_answer(tmt_t *tmt, const char *a) {
 
 void input_callback(tmt_msg_t m, TMT *vt, const void *a, void *p) {
 	tmt_t *tmt = (tmt_t*)p;
+	if (tmt->vt == NULL || tmt->answer == NULL) return;
+
 	switch (m){
 		case TMT_MSG_BELL:
 			tmt->update_bell = 1;

--- a/lua_tmt.c
+++ b/lua_tmt.c
@@ -123,7 +123,7 @@ static int l_get_screen(lua_State *L) {
 	// ensure enough objects for later
 	unsigned int l = s->nline * s->ncol;
 	if (lua_rawlen(L, -1) < l) {
-		for (int i = lua_rawlen(L, -1) + 1; i <= l; i++) {
+		for (unsigned int i = lua_rawlen(L, -1) + 1; i <= l; i++) {
 			lua_newtable(L);
 			lua_rawseti(L, -2, i);
 		}

--- a/minivt.c
+++ b/minivt.c
@@ -1,0 +1,107 @@
+/** minivt - ANSI escape "parser" inspired by tmt
+ *
+ * MIT No Attribution
+ * 
+ * Copyright 2022 takase1121
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <string.h>
+#include <stdlib.h>
+
+#include "minivt.h"
+
+#define PARSE_ARG_MAX 16
+#define ANSI_ESC "\x1b"
+#define ANSI_SOS "X"
+#define ANSI_ST  "\\"
+#define MIN(a, b) ((a) > (b) ? (b) : (a))
+#define HANDLER(fn) static void fn(vt_parser_t *vt)
+
+enum {
+    S_NUL,
+    S_ESC,
+    S_ARG,
+    S_STR,
+    S_SES
+};
+
+struct vt_parser_s {
+    callback_t cb;
+    void *p;
+    int state, narg;
+    size_t args[PARSE_ARG_MAX], arg;
+};
+
+
+HANDLER(consumearg) {
+    if (vt->narg < PARSE_ARG_MAX)
+        vt->args[vt->narg++] = vt->arg;
+    vt->arg = 0;
+}
+
+HANDLER(resetarg) {
+    memset(vt->args, 0, sizeof(vt->args));
+    vt->arg = vt->narg = 0;
+}
+
+vt_parser_t *
+vtnew(callback_t cb, void *p) {
+    vt_parser_t *vt = malloc(sizeof(vt_parser_t));
+    if (vt == NULL) return NULL;
+    memset(vt, 0, sizeof(vt_parser_t));
+    vt->cb = cb;
+    vt->p = p;
+    return vt;
+}
+
+void
+vtparse(vt_parser_t *vt, const char *data, size_t len) {
+#define ON(S, C, A) if (vt->state == (S) && strchr(C, c)) { A; continue; }
+#define ON_ANY(S, A) if (vt->state == (S)) { A; continue; }
+#define DO(S, C, A) ON(S, C, consumearg(vt); A; resetarg(vt));
+#define CB(T) vt->cb(T, &ans, vt->p)
+#define BUF(T) int l = i - si - MIN(i, 1); if (l > 0) { ans.buffer.len = l; ans.buffer.b = data + si; CB(T); si = i + 1; }
+
+    vt_answer_t ans;
+    size_t si = 0;
+    for (size_t i = 0; i < len; i++) {
+        char c = data[i];
+        char cs[] = { c, '\0' };
+        ON(S_NUL, ANSI_ESC, vt->state = S_ESC)
+        ON(S_ESC, ANSI_SOS, vt->state = S_STR; BUF(VT_MSG_PASS))
+
+        /* ANYTHING BETWEEN THESE ARE NONSTANDARD EVENTS */
+        ON(S_STR, "P",          vt->state = S_ARG; resetarg(vt))
+        ON(S_ARG, ";",          consumearg(vt))
+        ON(S_ARG, "0123456789", vt->arg = vt->arg * 10 + atoi(cs))
+        DO(S_ARG, "R",          vt->state = S_STR; ans.point.r = vt->args[0]; ans.point.c = vt->args[1]; CB(VT_MSG_RESIZE))
+        /* END OF NONSTANDARD EVENTS */
+
+        ON(S_STR, ANSI_ESC, vt->state = S_SES)
+        ON(S_SES, ANSI_ST,  vt->state = S_NUL; BUF(VT_MSG_CONTENT); CB(VT_MSG_END))
+        ON_ANY(S_SES,       vt->state = S_STR)
+    }
+
+    if (len - si > 0) {
+        ans.buffer.len = len - si;
+        ans.buffer.b = data + si;
+        CB(vt->state >= S_STR ? VT_MSG_CONTENT : VT_MSG_PASS);
+    }
+}
+
+void
+vtfree(vt_parser_t *vt) {
+    if (vt != NULL) free(vt);
+}

--- a/minivt.h
+++ b/minivt.h
@@ -1,0 +1,43 @@
+/** minivt - ANSI escape "parser" inspired by tmt
+ *
+ * MIT No Attribution
+ * 
+ * Copyright 2022 takase1121
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef MINIVT_H
+#define MINIVT_H
+
+#include <stddef.h>
+enum {
+    VT_MSG_PASS,
+    VT_MSG_CONTENT,
+    VT_MSG_END,
+    VT_MSG_RESIZE
+};
+
+typedef struct vt_parser_s vt_parser_t;
+typedef union {
+    struct { size_t len; const char *b; } buffer;
+    struct { size_t r, c; } point;
+} vt_answer_t;
+
+typedef void (*callback_t)(int type, vt_answer_t *, void *);
+
+vt_parser_t *vtnew(callback_t cb, void *p);
+void vtparse(vt_parser_t *vt, const char *data, size_t len);
+void vtfree(vt_parser_t *vt);
+
+#endif

--- a/pty.c
+++ b/pty.c
@@ -1,38 +1,68 @@
 #include <pty.h>
 #include <unistd.h>
 #include <sys/wait.h>
+#include <sys/ioctl.h>
 #include <poll.h>
 #include <stdlib.h>
+#include <string.h>
 #include <errno.h>
 #include <stdio.h>
 
-#define BUFFER_SIZE 256
+#include "minivt.h"
+
+#define MIN(a, b) ((a) > (b) ? (b) : (a))
+#define MAX_PTY_SIZE 999
+#define BUFFER_SIZE 2048
+
+void callback(int type, vt_answer_t *ans, void *p) {
+    int master = *(int*)p;
+    struct winsize wp = { 0 };
+
+    switch (type) {
+    // FIXME: ignoring MSG_CONTENT here
+    case VT_MSG_PASS:
+        write(master, ans->buffer.b, ans->buffer.len);
+        break;
+    case VT_MSG_RESIZE:
+        wp.ws_col = MIN(MAX_PTY_SIZE, ans->point.c);
+        wp.ws_row = MIN(MAX_PTY_SIZE, ans->point.r);
+        ioctl(master, TIOCSWINSZ, &wp);
+        break;
+    }
+}
 
 int main(int argc, char **argv) {
-    int master;
+#define LOG_ERR(S) (err = errno, perror(S), err)
+    
+    int master, err;
+    pid_t pid;
 
-    pid_t pid = forkpty(&master, NULL, NULL, NULL);
-    if(pid == -1) {
-        // forkpty failed
-        int err = errno;
-        printf("Could not forkpty (%i)\n", err);
-        return errno;
+    if (argc < 2) {
+        fputs("insufficient arguments", stderr);
+        return EXIT_FAILURE;
     }
+
+    pid = forkpty(&master, NULL, NULL, NULL);
+    if(pid == -1)
+        return LOG_ERR("forkpty(): ");
+
     if (pid != 0) {
+        // parent
         struct pollfd fds[2] = {
             { .fd = master, .events = POLLIN },
             { .fd = STDIN_FILENO, .events = POLLIN },
         };
 
+        vt_parser_t *vt = vtnew(callback, &master);
         char buffer[BUFFER_SIZE];
         size_t length;
         int status;
 
         while (1) {
-            poll(&fds[0], 2, -1);
+            poll(fds, 2, -1);
             if (fds[1].revents & POLLIN) {
-                length = read(STDIN_FILENO, &buffer[0], BUFFER_SIZE);
-                write(master, &buffer[0], length);
+                length = read(STDIN_FILENO, buffer, BUFFER_SIZE);
+                vtparse(vt, buffer, length);
             }
             if (fds[0].revents & POLLIN) {
                 length = read(master, &buffer[0], BUFFER_SIZE);
@@ -41,20 +71,18 @@ int main(int argc, char **argv) {
 
             if (fds[0].revents & POLLHUP || fds[1].revents & POLLHUP) {
                 waitpid(pid, &status, 0);
-                printf("Terminated cleanly");
+                vtfree(vt);
                 return WEXITSTATUS(status);
             }
-
             if (fds[0].revents & POLLERR || fds[1].revents & POLLERR) {
-                printf("crashed!");
-                 return 1;
+                vtfree(vt);
+                return EXIT_FAILURE;
             }
         }
     } else {
         // child
         setenv("TERM", "ansi", 1);
-        printf("launching %s", argv[1]);
-        execvp(argv[1], &argv[1]);
-        return errno;
+        execvp(argv[1], argv + 1);
+        return LOG_ERR("execvp(): ");
     }
 }


### PR DESCRIPTION
Here's a few refactors for the code:

1. the indentation is fixed to 4 spaces
2. fix weird `package.cpath` and add support for loading dlls
3. Use `config.plugins` instead of `config`
4. move subprocess IO to a thread (instead of in View:update)
5. Rename `get_char_size` to `get_screen_char_size` since it's ambiguous
6. Move terminal resize to `update()` instead of `draw()`
7. Do not draw spaces (`\r\n\t\v\l `)
8. Pass varargs in `keymap.on_key_pressed` (needed in master)
9. Return char as string instead of number (wchar_t encoding cannot be assumed, it **must** be converted by libc)
10. Removed `time` field in `tmt:write`
11. `get_screen` returns a linear array instead of a 2D array
12. Fix memory leak where `tmt->answer` will be discarded without freeing
13. Remove unused macros
14. Shorten code by using some convenient lua functions

There is way too much to cover so I might forgot something. 